### PR TITLE
enable experimental project references support

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -26,6 +26,7 @@ const BASE_OVERRIDES = [
     extends: ["plugin:@starbeam-dev/typed-js"],
     parserOptions: {
       project: ["tsconfig.json"],
+      EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
     },
     rules: {
       "@typescript-eslint/triple-slash-reference": "off",
@@ -40,6 +41,7 @@ const BASE_OVERRIDES = [
     },
     parserOptions: {
       project: ["tsconfig.json"],
+      EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
     },
   },
 ] satisfies Linter.ConfigOverride<Linter.RulesRecord>[];
@@ -53,6 +55,7 @@ export const library = {
       extends: ["plugin:@starbeam-dev/tight"],
       parserOptions: {
         project: ["tsconfig.json"],
+        EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
       },
     },
   ],
@@ -67,6 +70,7 @@ export const tests = {
       extends: ["plugin:@starbeam-dev/loose"],
       parserOptions: {
         project: "tsconfig.json",
+        EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
       },
     },
   ],


### PR DESCRIPTION
required to support tsconfig references.
e.g. https://github.com/starbeamjs/starbeam/blob/bca55c9fb54d030b5a3076bea5bbb0649ec527d5/packages/preact/preact/tests/tsconfig.json#L14

it is disabled for other parts. but never enabled
https://github.com/search?q=repo%3Astarbeamjs%2Feslint-plugin%20EXPERIMENTAL_useSourceOfProjectReferenceRedirect&type=code